### PR TITLE
Add option to allow backwards word placement in the grid

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,13 +13,23 @@ function createEmptyGrid(size: number) {
 	);
 }
 
-function placeWords(grid: string[][], words: string[]) {
-	const directions = [
+const [allowBackwards, setAllowBackwards] = createSignal(false);
+
+function getDirections() {
+	const base = [
 		[0, 1], // right
 		[1, 0], // down
 		[1, 1], // diagonal down-right
 		[-1, 1], // diagonal up-right
 	];
+	if (allowBackwards()) {
+		return base.concat(base.map(([dr, dc]) => [-dr, -dc]));
+	}
+	return base;
+}
+
+function placeWords(grid: string[][], words: string[]) {
+	const directions = getDirections();
 	for (const word of words) {
 		let placed = false;
 		for (let attempts = 0; attempts < 100 && !placed; attempts++) {
@@ -168,6 +178,19 @@ function App() {
 	return (
 		<div class="flex flex-col items-center justify-center min-h-screen bg-gray-100">
 			<h1 class="text-3xl font-bold mb-4">Word Search Game</h1>
+			<div class="mb-2">
+				<label class="flex items-center gap-2">
+					<input
+						type="checkbox"
+						checked={allowBackwards()}
+						onInput={(e) => {
+							setAllowBackwards(e.currentTarget.checked);
+							resetGame();
+						}}
+					/>
+					Allow Backwards Words
+				</label>
+			</div>
 			<div class="mb-4">
 				Words to find:
 				<ul class="flex gap-4 mt-2">


### PR DESCRIPTION
Issue: #5 

This pull request introduces a new feature to the Word Search Game that allows players to toggle whether words can appear backwards in the grid. The changes include adding a checkbox to the UI for this toggle and updating the word placement logic to respect this setting.

### Feature: Allow Backwards Words

* **Added toggle for backwards words in the UI**: A checkbox labeled "Allow Backwards Words" was added to the `App` component. When toggled, it updates the `allowBackwards` state and resets the game to apply the new setting. (`src/App.tsx`, [src/App.tsxR181-R193](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R181-R193))
* **Updated word placement logic**: The `placeWords` function now uses a new `getDirections` helper function to determine valid directions based on the `allowBackwards` state. If backwards words are allowed, additional reverse directions are included. (`src/App.tsx`, [src/App.tsxL16-R32](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L16-R32))